### PR TITLE
Rename Gutenberg to Zola

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # Tinkering
 This is the source for my blog at [tinkering.xyz][mysite]. 
 
-The site is generated with [Gutenberg][gutenberg], a static site generator written in Rust. The [theme][mytheme] is my own fork of the [Hyde][hyde-gutenberg] theme provided by Gutenberg.
+The site is generated with [Zola][zola], a static site generator written in Rust. The [theme][mytheme] is my own fork of the [Hyde][hyde-zola] theme provided by Gutenberg.
 
 [mysite]: https://tinkering.xyz
 [mytheme]: https://github.com/zmitchell/hyde
-[gutenberg]: getgutenberg.io
-[hyde-gutenberg]: https://github.com/Keats/hyde
+[zola]: https://www.getzola.org/
+[hyde-zola]: https://github.com/getzola/hyde

--- a/config.toml
+++ b/config.toml
@@ -5,7 +5,7 @@ base_url = "https://tinkering.xyz"
 compile_sass = true
 
 # Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Gutenberg
+# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola.
 highlight_code = true
 
 # Basic info

--- a/content/about/index.md
+++ b/content/about/index.md
@@ -13,7 +13,7 @@ I'm finishing up the last year of my physics PhD at Purdue University, where I s
 
 I've been writing Python for a little over 5 years. I decided to try Rust for a side project and it was love at first sight ❤️. I've been tinkering away at things in Rust ever since. From there I developed an interest in systems programming.
 
-This blog is made using [Gutenberg](https://www.getgutenberg.io), a static site generator written in Rust ("Rewrite It In Rust" can apply to blogs too). The site is hosted on [Netlify](https://www.netlify.com), a service I can't believe is free.
+This blog is made using [Zola](https://www.getzola.org/), a static site generator written in Rust ("Rewrite It In Rust" can apply to blogs too). The site is hosted on [Netlify](https://www.netlify.com), a service I can't believe is free.
 
 If you need to reach me, you can find me in the following places:
 


### PR DESCRIPTION
The static site generator has had a new name for some time now, and `getgutenberg.io` is no longer available.

I looked at the changes to `public/` after `zola build`, but there were too many trivial but not meaningful differences to include here. I'm guessing there are some differences in the versions of Zola that we use. You will probably want to update `public/` if you merge this PR.